### PR TITLE
Update GameState.apply_move() in goboard_slow.py

### DIFF
--- a/code/dlgo/goboard_slow.py
+++ b/code/dlgo/goboard_slow.py
@@ -170,15 +170,14 @@ class GameState():
         self.previous_state = previous
         self.last_move = move
 
-    def apply_move(self, player, move):  # <1>
-        if player != self.next_player:
-            raise ValueError(player)
+    def apply_move(self, move):  # <1>
+        """Return the new GameState after applying the move."""
         if move.is_play:
             next_board = copy.deepcopy(self.board)
-            next_board.place_stone(player, move.point)
+            next_board.place_stone(self.next_player, move.point)
         else:
             next_board = self.board
-        return GameState(next_board, player.other, self, move)
+        return GameState(next_board, self.next_player.other, self, move)
 
     @classmethod
     def new_game(cls, board_size):


### PR DESCRIPTION
Page 48, Listing 3.19 it was required to do 

```python
def main():
    # ...
    while not game.is_over():
        # ...
        game = game.apply_move(bot_move)
```

but `goboard_slow.py` has still the old function signature.