### PR TITLE
implement: refer to all filesystem data by way of path of current script

### DIFF
--- a/code/dlgo/agent/alphago_tst.py
+++ b/code/dlgo/agent/alphago_tst.py
@@ -16,8 +16,12 @@ from dlgo.goboard_fast import GameState
 from keras.callbacks import ModelCheckpoint
 import h5py
 import numpy as np
+import os
+
+adirCode=os.path.dirname(os.path.abspath(__file__))
 
 class AlphaGoAgentTest(unittest.TestCase):
+
     def test_1_supervised_learning(self):
         rows, cols = 19, 19
         encoder = AlphaGoEncoder()
@@ -33,14 +37,14 @@ class AlphaGoAgentTest(unittest.TestCase):
         outputs = alphago_sl_policy.predict(inputs)
         assert(outputs.shape == (10, 361))
 
-        with h5py.File('test_alphago_sl_policy.h5', 'w') as sl_agent_out:
+        with h5py.File(os.path.join(adirCode,'test_alphago_sl_policy.h5'), 'w') as sl_agent_out:
             alphago_sl_agent.serialize(sl_agent_out)
 
     def test_2_reinforcement_learning(self):
         encoder = AlphaGoEncoder()
 
-        sl_agent = load_prediction_agent(h5py.File('test_alphago_sl_policy.h5'))
-        sl_opponent = load_prediction_agent(h5py.File('test_alphago_sl_policy.h5'))
+        sl_agent = load_prediction_agent(h5py.File(os.path.join(adirCode,'test_alphago_sl_policy.h5')))
+        sl_opponent = load_prediction_agent(h5py.File(os.path.join(adirCode,'test_alphago_sl_policy.h5')))
 
         alphago_rl_agent = PolicyAgent(sl_agent.model, encoder)
         opponent = PolicyAgent(sl_opponent.model, encoder)
@@ -50,10 +54,10 @@ class AlphaGoAgentTest(unittest.TestCase):
 
         alphago_rl_agent.train(experience)
 
-        with h5py.File('test_alphago_rl_policy.h5', 'w') as rl_agent_out:
+        with h5py.File(os.path.join(adirCode,'test_alphago_rl_policy.h5'), 'w') as rl_agent_out:
             alphago_rl_agent.serialize(rl_agent_out)
 
-        with h5py.File('test_alphago_rl_experience.h5', 'w') as exp_out:
+        with h5py.File(os.path.join(adirCode,'test_alphago_rl_experience.h5'), 'w') as exp_out:
            experience.serialize(exp_out)        
 
     def test_3_alphago_value(self):
@@ -64,17 +68,17 @@ class AlphaGoAgentTest(unittest.TestCase):
 
         alphago_value = ValueAgent(alphago_value_network, encoder)
 
-        experience = load_experience(h5py.File('test_alphago_rl_experience.h5', 'r'))
+        experience = load_experience(h5py.File(os.path.join(adirCode,'test_alphago_rl_experience.h5'), 'r'))
 
         alphago_value.train(experience)
 
-        with h5py.File('test_alphago_value.h5', 'w') as value_agent_out:
+        with h5py.File(os.path.join(adirCode,'test_alphago_value.h5', 'w')) as value_agent_out:
             alphago_value.serialize(value_agent_out)
 
     def test_4_alphago_mcts(self):
-        fast_policy = load_prediction_agent(h5py.File('test_alphago_sl_policy.h5', 'r'))
-        strong_policy = load_policy_agent(h5py.File('test_alphago_rl_policy.h5', 'r'))
-        value = load_value_agent(h5py.File('test_alphago_value.h5', 'r'))
+        fast_policy = load_prediction_agent(h5py.File(os.path.join(adirCode,'test_alphago_sl_policy.h5'), 'r'))
+        strong_policy = load_policy_agent(h5py.File(os.path.join(adirCode,'test_alphago_rl_policy.h5'), 'r'))
+        value = load_value_agent(h5py.File(os.path.join(adirCode,'test_alphago_value.h5'), 'r'))
 
         alphago = AlphaGoMCTS(strong_policy, fast_policy, value,
                               num_simulations=20, depth=5, rollout_limit=10)

--- a/code/dlgo/gtp/play_local.py
+++ b/code/dlgo/gtp/play_local.py
@@ -147,7 +147,11 @@ class LocalGtpBot:
 
 
 if __name__ == "__main__":
-    bot = load_prediction_agent(h5py.File("../../agents/betago.hdf5", "r"))
+    import os
+    adirCode=os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+    afileBetago=os.path.join(adirCode,"agents/betago.hdf5")
+    bot = load_prediction_agent(h5py.File(afileBetago, "r"))
     gnu_go = LocalGtpBot(go_bot=bot, termination=PassWhenOpponentPasses(),
                          handicap=0, opponent='pachi', )
     gnu_go.run()

--- a/code/dlgo/nn/load_mnist.py
+++ b/code/dlgo/nn/load_mnist.py
@@ -3,6 +3,8 @@ import six.moves.cPickle as pickle
 import gzip
 import numpy as np
 
+import os
+adirCode=os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 def encode_label(j):  # <1>
     e = np.zeros((10, 1))
@@ -23,7 +25,8 @@ def shape_data(data):
 
 
 def load_data():
-    with gzip.open('mnist.pkl.gz', 'rb') as f:
+    afileMnist=os.path.join(adirCode,'dlgo/nn/mnist.pkl.gz')
+    with gzip.open(afileMnist, 'rb') as f:
         train_data, validation_data, test_data = pickle.load(f)  # <4>
 
     return shape_data(train_data), shape_data(test_data)  # <5>

--- a/code/examples/play_local_bot.py
+++ b/code/examples/play_local_bot.py
@@ -4,7 +4,11 @@ from dlgo.agent.termination import PassWhenOpponentPasses
 from dlgo.agent.predict import load_prediction_agent
 import h5py
 
-bot = load_prediction_agent(h5py.File("../agents/betago.hdf5", "r"))
+import os
+adirCode=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+afileBetago=os.path.join(adirCode,"agents/betago.hdf5")
+bot = load_prediction_agent(h5py.File(afileBetago, "r"))
 
 gtp_bot = LocalGtpBot(go_bot=bot, termination=PassWhenOpponentPasses(),
                       handicap=0, opponent='pachi')

--- a/code/examples/train_generator.py
+++ b/code/examples/train_generator.py
@@ -7,6 +7,9 @@ from keras.models import Sequential
 from keras.layers.core import Dense
 from keras.callbacks import ModelCheckpoint  # <1>
 
+import os
+adirCode=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 # <1> With model checkpoints we can store progress for time-consuming experiments
 # end::train_generator_imports[]
 
@@ -40,12 +43,13 @@ model.compile(loss='categorical_crossentropy', optimizer='sgd', metrics=['accura
 # tag::train_generator_fit[]
 epochs = 5
 batch_size = 128
+afileCheckpoint=os.path.join(adirCode,'../checkpoints/small_model_epoch_{epoch}.h5')
 model.fit_generator(generator=generator.generate(batch_size, num_classes),  # <1>
                     epochs=epochs,
                     steps_per_epoch=generator.get_num_samples() / batch_size,  # <2>
                     validation_data=test_generator.generate(batch_size, num_classes),  # <3>
                     validation_steps=test_generator.get_num_samples() / batch_size,  # <4>
-                    callbacks=[ModelCheckpoint('../checkpoints/small_model_epoch_{epoch}.h5')])  # <5>
+                    callbacks=[ModelCheckpoint(afileCheckpoint)])  # <5>
 
 model.evaluate_generator(generator=test_generator.generate(batch_size, num_classes),
                          steps=test_generator.get_num_samples() / batch_size)  # <6>

--- a/code/run_gtp.py
+++ b/code/run_gtp.py
@@ -4,7 +4,11 @@ from dlgo.agent.predict import load_prediction_agent
 from dlgo.agent import termination
 import h5py
 
-model_file = h5py.File("agents/betago.hdf5", "r")
+import os
+adirCode=os.path.dirname(os.path.abspath(__file__))
+
+afileBetago=os.path.join(adirCode,"agents/betago.hdf5")
+model_file = h5py.File(afileBetago, "r")
 agent = load_prediction_agent(model_file)
 strategy = termination.get("opponent_passes")
 termination_agent = termination.TerminationAgent(agent, strategy)

--- a/code/run_gtp_aws.py
+++ b/code/run_gtp_aws.py
@@ -4,7 +4,11 @@ from dlgo.agent.predict import load_prediction_agent
 from dlgo.agent import termination
 import h5py
 
-model_file = h5py.File("agents/betago.hdf5", "r")
+import os
+adirCode=os.path.dirname(os.path.abspath(__file__))
+
+afileBetago=os.path.join(adirCode,"agents/betago.hdf5")
+model_file = h5py.File(afileBetago, "r")
 agent = load_prediction_agent(model_file)
 strategy = termination.get("opponent_passes")
 termination_agent = termination.TerminationAgent(agent, strategy)


### PR DESCRIPTION
I am working through the with some friends at the Seattle Go Center.

I have noticed with some of the users more experienced with Go than with programming, the current working directory required to get the code to work is often confusing.

The following change makes each program find its filesystem data relative to its own program path.  That way, programs will always find their data files so long as the code and data is kept together, as it is in the git repository.

Note that one data file, mnist.pkl.gz, is in a subdirectory of code/dlgo.  That means the code can be put into a pip package and dissociated from the data.  So it appears mnist.pkl.gz is already broken in the pip package.  I'm going to semi-arbitrarily choose to include mnist.pkl.gz in this commit.

See #12 for underlying questions on the defacto requirements for mnist.pkl.gz.