### PR TITLE
fix bug: Loading pickled version of mnist crashes on python 3 #12

### DIFF
--- a/code/dlgo/nn/load_mnist.py
+++ b/code/dlgo/nn/load_mnist.py
@@ -19,12 +19,14 @@ def shape_data(data):
 
     labels = [encode_label(y) for y in data[1]]  # <2>
 
-    return zip(features, labels)  # <3>
+    return list(zip(features, labels))  # <3>
 
 
 def load_data():
     with gzip.open('mnist.pkl.gz', 'rb') as f:
-        train_data, validation_data, test_data = pickle.load(f)  # <4>
+        data = pickle._Unpickler(f)
+        data.encoding = 'latin1'  # set encoding
+        train_data, validation_data, test_data = data.load()
 
     return shape_data(train_data), shape_data(test_data)  # <5>
 


### PR DESCRIPTION
  Incorporates pickling arguments suggested by maxpumperla
  https://github.com/maxpumperla/deep_learning_and_the_game_of_go/issues/12

Before submitting a pull request, note that `master` and the respective
chapter branches need to stay in sync with the print version of the book.

- If your PR consists of clarifications, bug fixes, or other vital enhancements, please submit your PR against `master`.
- If your PR has performance improvements, simplifications, added functionality that would alter the main text of the book etc., please open your PR against the `improvements` branch.

Should your current PR mix these types of changes, please consider to split it accordingly. Thank you!