### PR TITLE
Correcting _remove_string to fix ko detection

### DIFF
--- a/code/dlgo/goboard_slow.py
+++ b/code/dlgo/goboard_slow.py
@@ -108,7 +108,7 @@ class Board():  # <1>
                     continue
                 if neighbor_string is not string:
                     neighbor_string.add_liberty(point)
-            self._grid[point] = None
+            del(self._grid[point])
 # <1> Removing a string can create liberties for other strings.
 # end::board_remove[]
 


### PR DESCRIPTION
Given a specific board state, if one piece is placed and then removed, the initial and final board configurations are the same, but in the dictionary _grid of the first one there will be no entry for the Point where the stone was placed, while in the _grid of the second one there will be an entry pointing to None. This makes the equality check of situation for ko to return False, since the dictionaries are different, but the states are the same and there should be a ko. I came across examples of this behavior.

In goboard_slow.py, in the _remove_string method, the last line is changed so the whole key is deleted instead of it being linked to None.

Before submitting a pull request, note that `master` and the respective
chapter branches need to stay in sync with the print version of the book.

- If your PR consists of clarifications, bug fixes, or other vital enhancements, please submit your PR against `master`.
- If your PR has performance improvements, simplifications, added functionality that would alter the main text of the book etc., please open your PR against the `improvements` branch.

Should your current PR mix these types of changes, please consider to split it accordingly. Thank you!