### PR TITLE
fix alpha beta to do more pruning

### DIFF
--- a/code/dlgo/minimax/alphabeta.py
+++ b/code/dlgo/minimax/alphabeta.py
@@ -40,7 +40,7 @@ def alpha_beta_result(game_state, max_depth, best_black, best_white, eval_fn):
             if best_so_far > best_white:                       # <8>
                 best_white = best_so_far                       # <8>
             outcome_for_black = -1 * best_so_far               # <9>
-            if outcome_for_black < best_black:                 # <9>
+            if outcome_for_black <= best_black:                # <9>
                 return best_so_far                             # <9>
 # end::alpha-beta-prune-2[]
 # tag::alpha-beta-prune-3[]
@@ -48,7 +48,7 @@ def alpha_beta_result(game_state, max_depth, best_black, best_white, eval_fn):
             if best_so_far > best_black:                       # <10>
                 best_black = best_so_far                       # <10>
             outcome_for_white = -1 * best_so_far               # <11>
-            if outcome_for_white < best_white:                 # <11>
+            if outcome_for_white <= best_white:                # <11>
                 return best_so_far                             # <11>
 # end::alpha-beta-prune-3[]
 # tag::alpha-beta-prune-4[]
@@ -86,9 +86,9 @@ class AlphaBetaAgent(Agent):
                 best_moves = [possible_move]
                 best_score = our_best_outcome
                 if game_state.next_player == Player.black:
-                    best_black = best_score
+                    best_black = best_score-1
                 elif game_state.next_player == Player.white:
-                    best_white = best_score
+                    best_white = best_score-1
             elif our_best_outcome == best_score:
                 # This is as good as our previous best move.
                 best_moves.append(possible_move)


### PR DESCRIPTION
Hello,

Thank you for a great book :)

I played with the alpha beta code, and I noticed that it's rather slow.

The issue turns out to be rather simple, after comparing with the canonical alpha beta algorithm:
- https://www.freecodecamp.org/news/simple-chess-ai-step-by-step-1d55a9266977/
- https://www.chessprogramming.org/Alpha-Beta

Instead of using `<` one can use `<=` in the comparisons `outcome... < best...`.

However for this to work with picking _all_ best moves, one should change the top level to either not do any alpha beta optimizations or to restore the `<` behavior by being over cautious (e.g. substracting 1 on the best score).

The difference is very significant. You can play with the number of positions evaluated here:
- http://jsfiddle.net/namin/ezn0o3jL/

In summary, for depth 3, we go from
12424
to
1713
positions evaluated
for the black move after white move pawn e4.

This change also seems to speed up `alpha_beta_go.py`.

Note as well that I am happy to provide a chess hook in the style of the `ttt` directory for tic tac toe. Please let me know if you'd like that.

Thank you.