### PR TITLE
Chess Hook

### DIFF
--- a/code/alpha_beta_chess.py
+++ b/code/alpha_beta_chess.py
@@ -1,0 +1,55 @@
+from six.moves import input
+
+import chess as _chess
+from dlgo import chess
+from dlgo.gotypes import Player
+from dlgo import minimax
+
+piece_values = {_chess.KING: 0,
+                _chess.PAWN: 1,
+                _chess.BISHOP: 3,
+                _chess.KNIGHT: 3,
+                _chess.ROOK: 5,
+                _chess.QUEEN: 9}
+
+def static_evaluation(game):
+    board = game.board
+    score = 0
+    for piece in board.piece_map().values():
+        value = piece_values[piece.piece_type]
+        factor = 1 if piece.color == board.turn else -1
+        score += factor * value
+    score -= 100 if board.is_checkmate() else 0
+    return score
+
+def move_from_uci(game, uci):
+    try:
+        move = _chess.Move.from_uci(uci)
+    except ValueError:
+        print('expected an UCI move')
+        return None
+    if not game.is_valid_move(move):
+        print('expected a valid move')
+        return None
+    return move
+
+def main():
+    game = chess.GameState.new_game()
+    bot = minimax.AlphaBetaAgent(3, static_evaluation)
+
+    while not game.is_over():
+        print(game.board)
+        if game.next_player == Player.white:
+            human_move = input('-- ')
+            move = move_from_uci(game, human_move.strip())
+            if move is None:
+                print('try again, e.g., %s' % game.legal_moves()[0].uci())
+                continue
+        else:
+            move = bot.select_move(game)
+        print(move)
+        game = game.apply_move(move)
+
+
+if __name__ == '__main__':
+    main()

--- a/code/dlgo/chess/README.md
+++ b/code/dlgo/chess/README.md
@@ -1,0 +1,24 @@
+Chess
+-----
+
+This directory provides a chess `dlgo`-compliant `GameState`, so that
+some parts of the book can be tried with chess, in addition to Go and
+TicTacToe.
+
+At the moment, the code supports `../minimax/alphabeta.py`,
+see the example `../../alpha_beta_chess.py`,
+which can be run from its directory with `python alpha_beta_chess.py`.
+
+Eventually, it would be interesting to support more of the book with
+chess in addition to go.
+
+## Dependencies
+
+The code is a shallow wrapping of the `python-chess` library, which is
+usually imported with `import chess`.
+
+Here, we use `import chess as _chess` and reserve the name `chess` for
+the `dlgo.chess` code.
+
+To install [`python-chess`](https://python-chess.readthedocs.io/en/latest/),
+run `pip install python-chess`.

--- a/code/dlgo/chess/__init__.py
+++ b/code/dlgo/chess/__init__.py
@@ -1,0 +1,1 @@
+from dlgo.chess.chessboard import *

--- a/code/dlgo/chess/chessboard.py
+++ b/code/dlgo/chess/chessboard.py
@@ -1,0 +1,36 @@
+import chess as _chess
+from dlgo.gotypes import Player
+
+__all__ = [
+    'GameState',
+]
+
+class GameState:
+    def __init__(self, board):
+        self.board = board
+        self.next_player = Player.white if board.turn else Player.black
+
+    def apply_move(self, move):
+        """Return the new GameState after applying the move."""
+        next_board = self.board.copy()
+        next_board.push(move)
+        return GameState(next_board)
+
+    @classmethod
+    def new_game(cls):
+        board = _chess.Board()
+        return GameState(board)
+
+    def is_valid_move(self, move):
+        return (move in self.board.legal_moves)
+
+    def legal_moves(self):
+        return list(self.board.legal_moves)
+
+    def is_over(self):
+        return self.board.is_game_over()
+
+    def winner(self):
+        if self.board.is_checkmate():
+            return Player.black if self.board.turn else Player.white
+        return None


### PR DESCRIPTION
As promised, a chess hook on top of python-chess
https://python-chess.readthedocs.io/en/latest/

- shallow: does not wrap python-chess

- tiny: only provides GameState for now, which is enough to run the
  alpha beta agent

- incomplete: it would be interesting to support other parts of the book...

Suggestions welcome... might not be worth merging as is. In addition, this creates a dependency to python-chess, so maybe not ideal to include in the dlgo lib.

Thanks :)