### PR TITLE
Remove duplicate line in Board#place_stone in goboard.py

### DIFF
--- a/code/dlgo/goboard.py
+++ b/code/dlgo/goboard.py
@@ -88,7 +88,6 @@ class Board:
             else:
                 if neighbor_string not in adjacent_opposite_color:
                     adjacent_opposite_color.append(neighbor_string)
-        new_string = GoString(player, [point], liberties)
 # tag::apply_zobrist[]
         new_string = GoString(player, [point], liberties)  # <1>
 


### PR DESCRIPTION
While reading the chapter 3 I have noticed that this line 
`new_string = GoString(player, [point], liberties)`
 is duplicated as part of the updated implementation using zobrist hashing.
I'm assuming this was a typo.
